### PR TITLE
Refactor/builder with strategy

### DIFF
--- a/src/catplus-common/src/graph/insert_into.rs
+++ b/src/catplus-common/src/graph/insert_into.rs
@@ -1,10 +1,11 @@
-use sophia::inmem::graph::LightGraph;
+use crate::graph::{
+    graph_builder::{GraphBuilder, OutputNodeStrategy},
+    utils::{generate_bnode_term, generate_iri_term},
+};
 use sophia_api::{
     graph::MutableGraph,
     term::{SimpleTerm, Term},
 };
-
-use crate::graph::utils::generate_bnode_term;
 
 /// Used in [InsertIntoGraph::attach_and_insert].
 #[derive(Clone)]
@@ -18,18 +19,32 @@ pub struct Link<'a, 'b, 'c> {
 /// by different types.
 pub trait InsertIntoGraph {
     /// Inserts `&self` into `graph` with subject IRI `iri`
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()>;
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()>;
 
     /// Inserts `&self` into `graph` with subject IRI `iri` (default to a blank node)
     /// and "attach" self to an existing node with an additional triple.
-    fn attach_into(&self, graph: &mut LightGraph, attach: Link) -> anyhow::Result<()> {
-        let iri = attach.target_iri.unwrap_or_else(|| self.get_uri());
-        _ = graph.insert(&attach.source_iri, &attach.pred, &iri);
+    fn attach_into(&self, builder: &mut GraphBuilder, attach: Link) -> anyhow::Result<()> {
+        let strategy = &builder.node_strategy;
+        let target_node = match attach.target_iri {
+            Some(target) => target, // Use provided target IRI directly
+            None => {
+                // No target IRI provided, decide default based on strategy
+                match strategy {
+                    OutputNodeStrategy::Iri => self.get_uri(), // Default to IRI generation/retrieval
+                    OutputNodeStrategy::BNode => generate_bnode_term(), // Default to BNode generation
+                }
+            }
+        };
+        _ = builder.graph.insert(&attach.source_iri, &attach.pred, &target_node);
 
-        self.insert_into(graph, iri)
+        self.insert_into(builder, target_node)
     }
 
     fn get_uri(&self) -> SimpleTerm<'static> {
+        generate_iri_term()
+    }
+
+    fn get_bnode(&self) -> SimpleTerm<'static> {
         generate_bnode_term()
     }
 }
@@ -39,16 +54,16 @@ impl<T> InsertIntoGraph for Option<T>
 where
     T: InsertIntoGraph,
 {
-    fn insert_into(&self, archive: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, archive: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         if let Some(v) = self {
             v.insert_into(archive, iri)?
         }
         Ok(())
     }
 
-    fn attach_into(&self, graph: &mut LightGraph, attach: Link) -> anyhow::Result<()> {
+    fn attach_into(&self, builder: &mut GraphBuilder, attach: Link) -> anyhow::Result<()> {
         if let Some(v) = self {
-            v.attach_into(graph, attach)?
+            v.attach_into(builder, attach)?
         }
         Ok(())
     }
@@ -58,16 +73,16 @@ impl<T> InsertIntoGraph for Vec<T>
 where
     T: InsertIntoGraph,
 {
-    fn insert_into(&self, graph: &mut LightGraph, _iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for item in self {
-            item.insert_into(graph, item.get_uri())?;
+            item.insert_into(builder, iri.clone())?;
         }
         Ok(())
     }
 
-    fn attach_into(&self, graph: &mut LightGraph, attach: Link) -> anyhow::Result<()> {
+    fn attach_into(&self, builder: &mut GraphBuilder, attach: Link) -> anyhow::Result<()> {
         for item in self {
-            item.attach_into(graph, attach.clone())?;
+            item.attach_into(builder, attach.clone())?;
         }
         Ok(())
     }
@@ -75,14 +90,14 @@ where
 
 /// Default implementation for [SimpleTerm].
 impl<'a> InsertIntoGraph for SimpleTerm<'a> {
-    fn insert_into(&self, _graph: &mut LightGraph, _iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, _builder: &mut GraphBuilder, _iri: SimpleTerm) -> anyhow::Result<()> {
         unimplemented!("cannot insert {:?} into graph, use `attach_and_insert`", &self)
     }
 
-    fn attach_into(&self, graph: &mut LightGraph, attach: Link) -> anyhow::Result<()> {
+    fn attach_into(&self, builder: &mut GraphBuilder, attach: Link) -> anyhow::Result<()> {
         assert!(!self.is_triple());
 
-        _ = graph.insert(&attach.source_iri, &attach.pred, self);
+        _ = builder.graph.insert(&attach.source_iri, &attach.pred, self);
 
         Ok(())
     }

--- a/src/catplus-common/src/graph/utils.rs
+++ b/src/catplus-common/src/graph/utils.rs
@@ -4,9 +4,19 @@ use sophia_api::{
 };
 use uuid::Uuid;
 
+pub const EX_BASE: &str = "http://example.org/";
+
 pub fn generate_bnode_term() -> SimpleTerm<'static> {
     let identifier = Uuid::new_v4().to_string();
     let bnode = BnodeId::new_unchecked(identifier);
 
     bnode.try_into_term().expect("Failed to convert BnodeId to SimpleTerm")
+}
+
+pub fn generate_iri_term() -> SimpleTerm<'static> {
+    let identifier = Uuid::new_v4().to_string();
+    let iri_string = format!("{}{}", EX_BASE, identifier);
+    let iri = IriRef::new_unchecked(iri_string);
+
+    iri.try_into_term().expect("Failed to convert Iri to SimpleTerm")
 }

--- a/src/catplus-common/src/models/agilent.rs
+++ b/src/catplus-common/src/models/agilent.rs
@@ -1,6 +1,6 @@
 use crate::{
     graph::{
-        graph_builder::{GraphBuilder, OutputNodeStrategy},
+        graph_builder::GraphBuilder,
         insert_into::{InsertIntoGraph, Link},
         namespaces::{allodc, allores, allorole, cat, obo, qb, qudt},
     },
@@ -8,9 +8,7 @@ use crate::{
 };
 
 use serde::{Deserialize, Serialize};
-use sophia::{
-    api::ns::{rdf, rdfs, xsd},
-};
+use sophia::api::ns::{rdf, rdfs, xsd};
 use sophia_api::term::{SimpleTerm, Term};
 
 #[derive(Deserialize)]
@@ -20,8 +18,8 @@ pub struct LiquidChromatographyAggregateDocumentWrapper {
 }
 
 impl InsertIntoGraph for LiquidChromatographyAggregateDocumentWrapper {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
-        self.liquid_chromatography_aggregate_document.insert_into(graph, iri)
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
+        self.liquid_chromatography_aggregate_document.insert_into(builder, iri)
     }
 }
 

--- a/src/catplus-common/src/models/agilent.rs
+++ b/src/catplus-common/src/models/agilent.rs
@@ -1,5 +1,6 @@
 use crate::{
     graph::{
+        graph_builder::{GraphBuilder, OutputNodeStrategy},
         insert_into::{InsertIntoGraph, Link},
         namespaces::{allodc, allores, allorole, cat, obo, qb, qudt},
     },
@@ -9,7 +10,6 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use sophia::{
     api::ns::{rdf, rdfs, xsd},
-    inmem::graph::LightGraph,
 };
 use sophia_api::term::{SimpleTerm, Term};
 
@@ -34,14 +34,14 @@ pub struct LiquidChromatographyAggregateDocument {
 }
 
 impl InsertIntoGraph for LiquidChromatographyAggregateDocument {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &allores::AFR_0002524.as_simple() as &dyn InsertIntoGraph),
             (cat::hasLiquidChromatography, &self.liquid_chromatography_document),
             (allores::AFR_0002526, &self.device_system_document),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -57,18 +57,18 @@ pub struct LiquidChromatographyDocument {
 }
 
 impl InsertIntoGraph for LiquidChromatographyDocument {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &allores::AFR_0002525.as_simple() as &dyn InsertIntoGraph),
             (allores::AFR_0001116, &self.analyst.as_simple()),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
         // NOTE: measurement_aggregate_document is not materliazed in the ontology -> we will attach measurement_document directly to LiquidChromatigraphyDocument
-        let _ = &self.measurement_aggregate_document.insert_into(graph, iri)?;
+        let _ = &self.measurement_aggregate_document.insert_into(builder, iri)?;
         Ok(())
     }
 }
@@ -80,10 +80,10 @@ pub struct MeasurementAggregateDocument {
 }
 
 impl InsertIntoGraph for MeasurementAggregateDocument {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         // NOTE: measurement_aggregate_document is not materliazed in the ontology -> we will attach measurement_document directly to LiquidChromatigraphyDocument
         let _ = &self.measurement_documents.attach_into(
-            graph,
+            builder,
             Link {
                 source_iri: iri.clone(),
                 pred: allores::AFR_0002374.as_simple(),
@@ -122,7 +122,7 @@ pub struct MeasurementDocument {
 }
 
 impl InsertIntoGraph for MeasurementDocument {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &allores::AFR_0002375.as_simple() as &dyn InsertIntoGraph),
             (allores::AFR_0001121, &self.measurement_identifier.as_simple()),
@@ -138,7 +138,7 @@ impl InsertIntoGraph for MeasurementDocument {
             (allores::AFR_0002659, &self.processed_data_document),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -150,12 +150,12 @@ impl InsertIntoGraph for MeasurementDocument {
 pub struct ChromatographyColumnDocument {}
 
 impl InsertIntoGraph for ChromatographyColumnDocument {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in
             [(rdf::type_, &cat::ChromatographyColumnDocument.as_simple() as &dyn InsertIntoGraph)]
         {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -172,7 +172,7 @@ pub struct DeviceSystemDocument {
 }
 
 impl InsertIntoGraph for DeviceSystemDocument {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &cat::DeviceSystemDocument.as_simple() as &dyn InsertIntoGraph),
             (allores::AFR_0002722, &self.device_document),
@@ -182,7 +182,7 @@ impl InsertIntoGraph for DeviceSystemDocument {
             ),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -211,7 +211,7 @@ pub struct DeviceDocument {
 }
 
 impl InsertIntoGraph for DeviceDocument {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &allores::AFR_0002567.as_simple() as &dyn InsertIntoGraph),
             (allores::AFR_0002018, &self.device_identifier.as_simple()),
@@ -225,7 +225,7 @@ impl InsertIntoGraph for DeviceDocument {
             //(allohdfcube::Index, &self.index)
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -240,13 +240,13 @@ pub struct ProcessedDataDocument {
 }
 
 impl InsertIntoGraph for ProcessedDataDocument {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &cat::ProcessedDataDocument.as_simple() as &dyn InsertIntoGraph),
             (allores::AFR_0000432, &self.peak_list),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -263,14 +263,14 @@ pub struct SampleDocument {
 }
 
 impl InsertIntoGraph for SampleDocument {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &cat::SampleDocument.as_simple() as &dyn InsertIntoGraph),
             (allores::AFR_0001118, &self.sample_identifier.as_simple()),
             (obo::IAO_0000590, &self.written_name.as_simple()),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -289,7 +289,7 @@ pub struct InjectionDocument {
 }
 
 impl InsertIntoGraph for InjectionDocument {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &cat::InjectionDocument.as_simple() as &dyn InsertIntoGraph),
             (allores::AFR_0001267, &self.autosampler_injection),
@@ -297,7 +297,7 @@ impl InsertIntoGraph for InjectionDocument {
             (allores::AFR_0002536, &(self.injection_time.as_str() * xsd::dateTime).as_simple()),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -314,7 +314,7 @@ pub struct ChromatogramDataCube {
 }
 
 impl InsertIntoGraph for ChromatogramDataCube {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &cat::ChromatogramDataCube.as_simple() as &dyn InsertIntoGraph),
             (obo::IAO_0000009, &self.label.as_ref().clone().map(|s| s.as_simple())),
@@ -322,7 +322,7 @@ impl InsertIntoGraph for ChromatogramDataCube {
             (allores::AFR_0000917, &self.identifier.as_ref().clone().map(|s| s.as_simple())),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -339,7 +339,7 @@ pub struct ThreeDimensionalUltravioletSpectrumDataCube {
 }
 
 impl InsertIntoGraph for ThreeDimensionalUltravioletSpectrumDataCube {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (
                 rdf::type_,
@@ -351,7 +351,7 @@ impl InsertIntoGraph for ThreeDimensionalUltravioletSpectrumDataCube {
             (allores::AFR_0000917, &self.identifier.as_simple()),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -368,7 +368,7 @@ pub struct ThreeDimensionalMassSpectrumDataCube {
 }
 
 impl InsertIntoGraph for ThreeDimensionalMassSpectrumDataCube {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (
                 rdf::type_,
@@ -379,7 +379,7 @@ impl InsertIntoGraph for ThreeDimensionalMassSpectrumDataCube {
             (allores::AFR_0000917, &self.identifier.as_simple()),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -394,7 +394,7 @@ pub struct AutosamplerInjectionVolumeSetting {
 }
 
 impl InsertIntoGraph for AutosamplerInjectionVolumeSetting {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (
                 rdf::type_,
@@ -404,7 +404,7 @@ impl InsertIntoGraph for AutosamplerInjectionVolumeSetting {
             (qudt::unit, &self.unit.iri().as_simple()),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -419,14 +419,14 @@ pub struct CubeStructure {
 }
 
 impl InsertIntoGraph for CubeStructure {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &cat::CubeStructure.as_simple() as &dyn InsertIntoGraph),
             (cat::measure, &self.measures),
             (cat::dimension, &self.dimensions),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -443,7 +443,7 @@ pub struct Measure {
 }
 
 impl InsertIntoGraph for Measure {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &allorole::AFRL_0000157.as_simple() as &dyn InsertIntoGraph),
             (allodc::componentDataType, &self.component_data_type.as_simple()),
@@ -451,7 +451,7 @@ impl InsertIntoGraph for Measure {
             (qudt::unit, &self.unit.iri().as_simple()),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -468,7 +468,7 @@ pub struct Dimension {
 }
 
 impl InsertIntoGraph for Dimension {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &cat::Dimension.as_simple() as &dyn InsertIntoGraph),
             (allodc::componentDataType, &self.component_data_type.as_simple()),
@@ -476,7 +476,7 @@ impl InsertIntoGraph for Dimension {
             (qudt::unit, &self.unit.iri().as_simple()),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }

--- a/src/catplus-common/src/models/core.rs
+++ b/src/catplus-common/src/models/core.rs
@@ -2,6 +2,7 @@
 // The structure follows the input data as descibed in the
 // https://github.com/sdsc-ordes/catplus-ontology see here for the expected Synth input data:
 // https://github.com/sdsc-ordes/catplus-ontology/tree/96091fd2e75e03de8a4c4d66ad502b2db27998bd/json-file/1-Synth
+use crate::graph::graph_builder::GraphBuilder;
 use crate::{
     graph::{
         insert_into::{InsertIntoGraph, Link},
@@ -11,7 +12,7 @@ use crate::{
 };
 use anyhow;
 use serde::{Deserialize, Serialize};
-use sophia::{api::ns::rdf, inmem::graph::LightGraph};
+use sophia::api::ns::rdf;
 use sophia_api::term::{SimpleTerm, Term};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -23,7 +24,7 @@ pub struct Plate {
 }
 
 impl InsertIntoGraph for Plate {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (prop, value) in [
             (rdf::type_, &cat::Plate.as_simple() as &dyn InsertIntoGraph),
             (cat::containerID, &self.container_id.as_simple() as &dyn InsertIntoGraph),
@@ -33,7 +34,7 @@ impl InsertIntoGraph for Plate {
             ),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: prop.as_simple(), target_iri: None },
             )?;
         }
@@ -51,7 +52,7 @@ pub struct Observation {
 
 /// Implementation for concrete [Observation].
 impl InsertIntoGraph for Observation {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (prop, value) in [
             (rdf::type_, &cat::Observation.as_simple() as &dyn InsertIntoGraph),
             (qudt::unit, &self.unit.iri().as_simple() as &dyn InsertIntoGraph),
@@ -59,7 +60,7 @@ impl InsertIntoGraph for Observation {
             (cat::errorMargin, &self.error_margin),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: prop.as_simple(), target_iri: None },
             )?;
         }
@@ -75,14 +76,14 @@ pub struct ErrorMargin {
 }
 
 impl InsertIntoGraph for ErrorMargin {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (prop, value) in [
             (rdf::type_, &cat::errorMargin.as_simple() as &dyn InsertIntoGraph),
             (qudt::unit, &self.unit.iri().as_simple() as &dyn InsertIntoGraph),
             (qudt::value, &self.value.as_simple()),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: prop.as_simple(), target_iri: None },
             )?;
         }
@@ -105,7 +106,7 @@ pub struct Sample {
 }
 
 impl InsertIntoGraph for Sample {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (prop, value) in [
             (rdf::type_, &cat::Sample.as_simple() as &dyn InsertIntoGraph),
             (cat::hasPlate, &self.has_plate),
@@ -116,7 +117,7 @@ impl InsertIntoGraph for Sample {
             (cat::hasSample, &self.has_sample),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: prop.as_simple(), target_iri: None },
             )?;
         }
@@ -140,7 +141,7 @@ pub struct SampleItem {
 }
 
 impl InsertIntoGraph for SampleItem {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (prop, value) in [
             (rdf::type_, &cat::Sample.as_simple() as &dyn InsertIntoGraph),
             (purl::identifier, &self.sample_id.as_simple()),
@@ -153,7 +154,7 @@ impl InsertIntoGraph for SampleItem {
             (cat::hasChemical, &self.has_chemical),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: prop.as_simple(), target_iri: None },
             )?;
         }
@@ -181,7 +182,7 @@ pub struct Chemical {
 }
 
 impl InsertIntoGraph for Chemical {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (prop, value) in [
             (rdf::type_, &obo::CHEBI_25367.as_simple() as &dyn InsertIntoGraph),
             (purl::identifier, &self.chemical_id.as_simple()),
@@ -196,7 +197,7 @@ impl InsertIntoGraph for Chemical {
             (obo::PATO_0001019, &self.density),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: prop.as_simple(), target_iri: None },
             )?;
         }
@@ -214,7 +215,7 @@ pub struct Well {
 }
 
 impl InsertIntoGraph for Well {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &cat::Well.as_simple() as &dyn InsertIntoGraph),
             (cat::hasPlate, &self.has_plate),
@@ -222,7 +223,7 @@ impl InsertIntoGraph for Well {
             (qudt::quantity, &self.quantity),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -330,7 +331,10 @@ mod tests {
     use sophia_api::term::Term;
 
     use crate::{
-        graph::{graph_builder::GraphBuilder, insert_into::InsertIntoGraph},
+        graph::{
+            graph_builder::{GraphBuilder, OutputNodeStrategy},
+            insert_into::InsertIntoGraph,
+        },
         models::{ErrorMargin, Observation},
     };
 
@@ -342,9 +346,9 @@ mod tests {
             error_margin: Some(ErrorMargin { value: 0.5, unit: Unit::DegC }),
         };
 
-        let mut b = GraphBuilder::new();
+        let mut b = GraphBuilder::new(OutputNodeStrategy::Iri);
         let i = IriRef::new_unchecked("http://test.com/my-obersvation");
-        observation.insert_into(&mut b.graph, i.as_simple())?;
+        observation.insert_into(&mut b, i.as_simple())?;
         println!("Graph\n{}", b.serialize_to_turtle().unwrap());
 
         Ok(())

--- a/src/catplus-common/src/models/core.rs
+++ b/src/catplus-common/src/models/core.rs
@@ -238,13 +238,13 @@ pub struct PeakList {
 }
 
 impl InsertIntoGraph for PeakList {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &cat::PeakList.as_simple() as &dyn InsertIntoGraph),
             (cat::Peak, &self.peak),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -279,7 +279,7 @@ pub struct Peak {
 }
 
 impl InsertIntoGraph for Peak {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &allores::AFR_0000413.as_simple() as &dyn InsertIntoGraph),
             (allores::AFR_0001164, &self.peak_identifier.as_simple()),
@@ -294,7 +294,7 @@ impl InsertIntoGraph for Peak {
             (allores::AFR_0001181, &self.peak_value_at_end),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -309,14 +309,14 @@ pub struct Measurement {
 }
 
 impl InsertIntoGraph for Measurement {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (prop, value) in [
             (rdf::type_, &cat::Measurement.as_simple() as &dyn InsertIntoGraph),
             (qudt::unit, &self.unit.iri().as_simple() as &dyn InsertIntoGraph),
             (qudt::value, &self.value.as_simple()),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: prop.as_simple(), target_iri: None },
             )?;
         }

--- a/src/catplus-common/src/models/hci.rs
+++ b/src/catplus-common/src/models/hci.rs
@@ -1,5 +1,6 @@
 use crate::{
     graph::{
+        graph_builder::GraphBuilder,
         insert_into::{InsertIntoGraph, Link},
         namespaces::{allocom, allohdf, allores, cat, obo, purl, schema},
     },
@@ -8,7 +9,7 @@ use crate::{
 
 use anyhow;
 use serde::{Deserialize, Serialize};
-use sophia::{api::ns::rdf, inmem::graph::LightGraph};
+use sophia::api::ns::rdf;
 use sophia_api::term::{SimpleTerm, Term};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -28,7 +29,7 @@ pub struct Campaign {
 }
 
 impl InsertIntoGraph for Campaign {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &cat::Campaign.as_simple() as &dyn InsertIntoGraph),
             (schema::name, &self.campaign_name.as_simple()),
@@ -42,7 +43,7 @@ impl InsertIntoGraph for Campaign {
             (cat::hasChemical, &self.has_chemical),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -60,7 +61,7 @@ pub struct Objective {
 }
 
 impl InsertIntoGraph for Objective {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &obo::IAO_0000005.as_simple()),
             (schema::name, &self.objective_name.as_simple()),
@@ -69,7 +70,7 @@ impl InsertIntoGraph for Objective {
             (allocom::AFC_0000090, &self.condition.as_simple()),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }
@@ -83,8 +84,8 @@ pub struct CampaignWrapper {
     pub has_campaign: Campaign,
 }
 impl InsertIntoGraph for CampaignWrapper {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
-        self.has_campaign.insert_into(graph, iri)
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
+        self.has_campaign.insert_into(builder, iri)
     }
 }
 
@@ -102,7 +103,7 @@ pub struct HciBatch {
 }
 
 impl InsertIntoGraph for HciBatch {
-    fn insert_into(&self, graph: &mut LightGraph, iri: SimpleTerm) -> anyhow::Result<()> {
+    fn insert_into(&self, builder: &mut GraphBuilder, iri: SimpleTerm) -> anyhow::Result<()> {
         for (pred, value) in [
             (rdf::type_, &cat::Batch.as_simple() as &dyn InsertIntoGraph),
             (purl::identifier, &self.batch_id.as_simple()),
@@ -116,7 +117,7 @@ impl InsertIntoGraph for HciBatch {
             ),
         ] {
             value.attach_into(
-                graph,
+                builder,
                 Link { source_iri: iri.clone(), pred: pred.as_simple(), target_iri: None },
             )?;
         }

--- a/src/converter/src/convert.rs
+++ b/src/converter/src/convert.rs
@@ -1,5 +1,8 @@
 use anyhow::{Context, Result};
-use catplus_common::graph::{graph_builder::GraphBuilder, insert_into::InsertIntoGraph};
+use catplus_common::graph::{
+    graph_builder::{GraphBuilder, OutputNodeStrategy},
+    insert_into::InsertIntoGraph,
+};
 use serde::{de::DeserializeOwned, Deserialize};
 
 // Derive Deserialize and ValueEnum
@@ -19,13 +22,17 @@ pub enum RdfFormat {
 ///
 /// # Returns
 /// A `Result` containing the serialized graph as a string or an error.
-pub fn json_to_rdf<T>(input_content: &str, format: &RdfFormat) -> Result<String>
+pub fn json_to_rdf<T>(
+    input_content: &str,
+    format: &RdfFormat,
+    output_node_strategy: &OutputNodeStrategy,
+) -> Result<String>
 where
     T: DeserializeOwned + InsertIntoGraph, // Trait bounds
 {
     let data: T = parse_json(input_content).context("Failed to parse JSON input")?;
 
-    let mut graph_builder = GraphBuilder::new();
+    let mut graph_builder = GraphBuilder::new(output_node_strategy.clone());
     graph_builder.insert(&data).context("Failed to build RDF graph")?;
 
     let serialized_graph = match format {

--- a/src/converter/src/main.rs
+++ b/src/converter/src/main.rs
@@ -1,8 +1,11 @@
 use anyhow::{Context, Result};
-use catplus_common::models::{
-    agilent::LiquidChromatographyAggregateDocumentWrapper, hci::CampaignWrapper, synth::SynthBatch,
+use catplus_common::{
+    graph::graph_builder::OutputNodeStrategy,
+    models::{
+        agilent::LiquidChromatographyAggregateDocumentWrapper, hci::CampaignWrapper,
+        synth::SynthBatch,
+    },
 };
-use catplus_common::graph::graph_builder::OutputNodeStrategy;
 use clap::Parser;
 use converter::convert::{json_to_rdf, RdfFormat};
 use serde::Deserialize;
@@ -96,7 +99,7 @@ fn main() -> Result<()> {
         InputType::Agilent => json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(
             &input_content,
             &args.format,
-            &output_node_strategy
+            &output_node_strategy,
         ),
     }
     .with_context(|| format!("Failed to convert JSON to RDF format '{:?}'", &args.format))?;

--- a/src/converter/tests/agilent_tests.rs
+++ b/src/converter/tests/agilent_tests.rs
@@ -1,4 +1,5 @@
 use catplus_common::{
+    graph::graph_builder::OutputNodeStrategy,
     models::agilent::LiquidChromatographyAggregateDocumentWrapper,
     rdf::rdf_parser::parse_turtle_to_graph,
 };
@@ -202,8 +203,9 @@ fn test_convert_liquid_chromatography() {
         }
     }
     "#;
+    let output_node_strategy = OutputNodeStrategy::BNode;
     let result =
-        json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(json_data, &output_format);
+        json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(json_data, &output_format, &output_node_strategy);
     println!("{:?}", result);
     let expected_ttl = r#"
 
@@ -369,8 +371,9 @@ fn test_convert_device_system_document() {
         }
     }
     "#;
+    let output_node_strategy = OutputNodeStrategy::BNode;
     let result =
-        json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(json_data, &output_format);
+        json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(json_data, &output_format, &output_node_strategy);
     let expected_ttl = r#"
     PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

--- a/src/converter/tests/agilent_tests.rs
+++ b/src/converter/tests/agilent_tests.rs
@@ -204,8 +204,11 @@ fn test_convert_liquid_chromatography() {
     }
     "#;
     let output_node_strategy = OutputNodeStrategy::BNode;
-    let result =
-        json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(json_data, &output_format, &output_node_strategy);
+    let result = json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(
+        json_data,
+        &output_format,
+        &output_node_strategy,
+    );
     println!("{:?}", result);
     let expected_ttl = r#"
 
@@ -372,8 +375,11 @@ fn test_convert_device_system_document() {
     }
     "#;
     let output_node_strategy = OutputNodeStrategy::BNode;
-    let result =
-        json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(json_data, &output_format, &output_node_strategy);
+    let result = json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(
+        json_data,
+        &output_format,
+        &output_node_strategy,
+    );
     let expected_ttl = r#"
     PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

--- a/src/converter/tests/hci_tests.rs
+++ b/src/converter/tests/hci_tests.rs
@@ -1,4 +1,7 @@
-use catplus_common::{models::hci::CampaignWrapper, rdf::rdf_parser::parse_turtle_to_graph};
+use catplus_common::{
+    graph::graph_builder::OutputNodeStrategy, models::hci::CampaignWrapper,
+    rdf::rdf_parser::parse_turtle_to_graph,
+};
 use converter::convert::{json_to_rdf, RdfFormat};
 use sophia_isomorphism::isomorphic_graphs;
 
@@ -105,7 +108,9 @@ fn test_convert_campaign() {
             }
         }
     "#;
-    let result = json_to_rdf::<CampaignWrapper>(json_data, &output_format);
+    let output_node_strategy = OutputNodeStrategy::BNode;
+    let result = json_to_rdf::<CampaignWrapper>(json_data, &output_format, &output_node_strategy);
+    println!("{:?}", result);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

--- a/src/converter/tests/synth_tests.rs
+++ b/src/converter/tests/synth_tests.rs
@@ -1,4 +1,7 @@
-use catplus_common::{models::synth::SynthBatch, rdf::rdf_parser::parse_turtle_to_graph};
+use catplus_common::{
+    graph::graph_builder::OutputNodeStrategy, models::synth::SynthBatch,
+    rdf::rdf_parser::parse_turtle_to_graph,
+};
 use converter::convert::{json_to_rdf, RdfFormat};
 use sophia_isomorphism::isomorphic_graphs;
 
@@ -22,7 +25,8 @@ fn test_convert_filtrate_action() {
             ]
         }
     "#;
-    let result = json_to_rdf::<SynthBatch>(json_data, &output_format);
+    let output_node_strategy = OutputNodeStrategy::BNode;
+    let result = json_to_rdf::<SynthBatch>(json_data, &output_format, &output_node_strategy);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -90,7 +94,8 @@ fn test_convert_pressure_action() {
             ]
         }
     "#;
-    let result = json_to_rdf::<SynthBatch>(json_data, &output_format);
+    let output_node_strategy = OutputNodeStrategy::BNode;
+    let result = json_to_rdf::<SynthBatch>(json_data, &output_format, &output_node_strategy);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -180,7 +185,8 @@ fn test_convert_set_temperature_action() {
                 ]
             }
         "#;
-    let result = json_to_rdf::<SynthBatch>(json_data, &output_format);
+    let output_node_strategy = OutputNodeStrategy::BNode;
+    let result = json_to_rdf::<SynthBatch>(json_data, &output_format, &output_node_strategy);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -339,7 +345,8 @@ fn test_convert_add_action() {
         ]
     }
     "#;
-    let result = json_to_rdf::<SynthBatch>(json_data, &output_format);
+    let output_node_strategy = OutputNodeStrategy::BNode;
+    let result = json_to_rdf::<SynthBatch>(json_data, &output_format, &output_node_strategy);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -485,7 +492,8 @@ fn test_convert_shake_action() {
             ]
         }
     "#;
-    let result = json_to_rdf::<SynthBatch>(json_data, &output_format);
+    let output_node_strategy = OutputNodeStrategy::BNode;
+    let result = json_to_rdf::<SynthBatch>(json_data, &output_format, &output_node_strategy);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -571,7 +579,8 @@ fn test_convert_set_vacuum_action() {
             ]
         }
     "#;
-    let result = json_to_rdf::<SynthBatch>(json_data, &output_format);
+    let output_node_strategy = OutputNodeStrategy::BNode;
+    let result = json_to_rdf::<SynthBatch>(json_data, &output_format, &output_node_strategy);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>


### PR DESCRIPTION
This PR adds a node strategy parameter on the CLI: this can be either `bnode` or `iri`. The graph builder implements these build strategies as follows:
- `bnode`: graph is build with bnodes only
- `iri`: graph is build with iri nodes only, using a uuid as identifier

These strategies can be extended later on by intermediate strategies that use a mixture of bnodes and iri and switch to identifiers other than `uuid`s but for debugging with shacl these two options are already a helpful start.