### PR TITLE
feat(builder): blank node materialization

### DIFF
--- a/src/catplus-common/src/graph/graph_builder.rs
+++ b/src/catplus-common/src/graph/graph_builder.rs
@@ -42,11 +42,14 @@ impl GraphBuilder {
             let new_subject = match subject {
                 SimpleTerm::BlankNode(s) => {
                     let new_iri = format!("{}{}", prefix.unwrap_or_default(), s.as_str());
-                    new_iri.to_owned()
+                    IriRef::new(new_iri.to_owned())
                 }
-                SimpleTerm::Iri(s) => s.as_str().to_owned(),
+                SimpleTerm::Iri(s) => {
+                    IriRef::new(s.as_str().to_owned())
+                }
+                ,
                 _ => panic!("Unexpected subject type"),
-            };
+            }?;
 
             // If the object is a blank node, replace it with a URI
             // In any other case, we just clone it
@@ -54,14 +57,14 @@ impl GraphBuilder {
                 SimpleTerm::BlankNode(o) => {
                     let new_o = format!("{}{}", prefix.unwrap_or_default(), o.as_str());
                     materialized_graph.insert(
-                        new_subject.as_simple(),
+                        new_subject,
                         predicate.clone(),
                         new_o.as_simple(),
                     )?;
                 }
                 _ => {
                     materialized_graph.insert(
-                        new_subject.as_simple(),
+                        new_subject,
                         predicate.clone(),
                         object.clone(),
                     )?;

--- a/src/catplus-common/src/graph/graph_builder.rs
+++ b/src/catplus-common/src/graph/graph_builder.rs
@@ -44,10 +44,7 @@ impl GraphBuilder {
                     let new_iri = format!("{}{}", prefix.unwrap_or_default(), s.as_str());
                     IriRef::new(new_iri.to_owned())
                 }
-                SimpleTerm::Iri(s) => {
-                    IriRef::new(s.as_str().to_owned())
-                }
-                ,
+                SimpleTerm::Iri(s) => IriRef::new(s.as_str().to_owned()),
                 _ => panic!("Unexpected subject type"),
             }?;
 
@@ -63,11 +60,7 @@ impl GraphBuilder {
                     )?;
                 }
                 _ => {
-                    materialized_graph.insert(
-                        new_subject,
-                        predicate.clone(),
-                        object.clone(),
-                    )?;
+                    materialized_graph.insert(new_subject, predicate.clone(), object.clone())?;
                 }
             };
         }

--- a/src/catplus-common/src/graph/graph_builder.rs
+++ b/src/catplus-common/src/graph/graph_builder.rs
@@ -41,21 +41,23 @@ impl GraphBuilder {
             // If the subject or object is a blank node, replace it with a URI
             let new_subject = match subject {
                 SimpleTerm::BlankNode(s) => {
-                    format!("{}{}", prefix.unwrap_or_default(), s.as_str())
+                    let new_iri = format!("{}{}", prefix.unwrap_or_default(), s.as_str());
+                    let new_s = new_iri.as_simple();
+                    new_s.clone()
                 },
-                _ => subject
+                _ => subject.clone()
             };
 
             let new_object = match object {
                 SimpleTerm::BlankNode(o) => {
                     let new_iri = format!("{}{}", prefix.unwrap_or_default(), o.as_str());
-                    let new_subject = SimpleTerm::Iri(new_iri.as_simple());
+                    let new_o = new_iri.as_simple();
                     new_o
                 },
-                _ => object
+                _ => *object
             };
             // Add the triple to the new graph
-            new_graph.insert(new_subject, predicate.clone(), new_object.clone())?
+            new_graph.insert(new_subject, predicate.clone(), new_object.clone())?;
         }
                     
 

--- a/src/catplus-common/src/graph/graph_builder.rs
+++ b/src/catplus-common/src/graph/graph_builder.rs
@@ -52,14 +52,14 @@ impl GraphBuilder {
             }?;
 
             // If the object is a blank node, replace it with a URI
-            // In any other case, we just clone it
+            // In any other case, we just clone it.
             match object {
                 SimpleTerm::BlankNode(o) => {
                     let new_o = format!("{}{}", prefix.unwrap_or_default(), o.as_str());
                     materialized_graph.insert(
                         new_subject,
                         predicate.clone(),
-                        new_o.as_simple(),
+                        IriRef::new(new_o.as_str().to_owned()).unwrap(),
                     )?;
                 }
                 _ => {

--- a/src/catplus-common/src/models/core.rs
+++ b/src/catplus-common/src/models/core.rs
@@ -343,7 +343,7 @@ mod tests {
         };
 
         let mut b = GraphBuilder::new();
-        let i = IriRef::new_unchecked("http://test.com/my-obersvation");
+        let i = IriRef::new_unchecked("http://test.com/my-observation");
         observation.insert_into(&mut b.graph, i.as_simple())?;
         println!("Graph\n{}", b.serialize_to_turtle().unwrap());
 

--- a/src/converter/src/convert.rs
+++ b/src/converter/src/convert.rs
@@ -19,7 +19,7 @@ pub enum RdfFormat {
 ///
 /// # Returns
 /// A `Result` containing the serialized graph as a string or an error.
-pub fn json_to_rdf<T>(input_content: &str, format: &RdfFormat) -> Result<String>
+pub fn json_to_rdf<T>(input_content: &str, format: &RdfFormat, materialize: bool) -> Result<String>
 where
     T: DeserializeOwned + InsertIntoGraph, // Trait bounds
 {
@@ -27,6 +27,12 @@ where
 
     let mut graph_builder = GraphBuilder::new();
     graph_builder.insert(&data).context("Failed to build RDF graph")?;
+
+    if materialize {
+        graph_builder
+            .materialize_blank_nodes(Some("http://example.org/"))
+            .context("Failed to materialize blank nodes")?;
+    }
 
     let serialized_graph = match format {
         RdfFormat::Jsonld => {

--- a/src/converter/src/convert.rs
+++ b/src/converter/src/convert.rs
@@ -30,7 +30,7 @@ where
 
     if materialize {
         graph_builder
-            .materialize_blank_nodes(Some("http://example.org/"))
+            .materialize_blank_nodes(Some("http://example.org/cat"))
             .context("Failed to materialize blank nodes")?;
     }
 

--- a/src/converter/src/convert.rs
+++ b/src/converter/src/convert.rs
@@ -30,7 +30,7 @@ where
 
     if materialize {
         graph_builder
-            .materialize_blank_nodes(Some("http://example.org/cat"))
+            .materialize_blank_nodes(Some("http://example.org/cat/resource/"))
             .context("Failed to materialize blank nodes")?;
     }
 

--- a/src/converter/src/main.rs
+++ b/src/converter/src/main.rs
@@ -66,8 +66,12 @@ fn main() -> Result<()> {
 
     // Unified conversion function with type selection
     let serialized_graph = match args.input_type {
-        InputType::Synth => json_to_rdf::<SynthBatch>(&input_content, &args.format, args.materialize),
-        InputType::HCI => json_to_rdf::<CampaignWrapper>(&input_content, &args.format, args.materialize),
+        InputType::Synth => {
+            json_to_rdf::<SynthBatch>(&input_content, &args.format, args.materialize)
+        }
+        InputType::HCI => {
+            json_to_rdf::<CampaignWrapper>(&input_content, &args.format, args.materialize)
+        }
         InputType::Agilent => json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(
             &input_content,
             &args.format,

--- a/src/converter/src/main.rs
+++ b/src/converter/src/main.rs
@@ -39,6 +39,10 @@ struct Args {
     /// Type of input data: "Turtle" or "Jsonld".
     #[arg(value_enum)]
     format: RdfFormat,
+
+    /// Materialize blank nodes
+    #[arg(long, default_value_t = false)]
+    materialize: bool,
 }
 
 fn main() -> Result<()> {
@@ -62,11 +66,12 @@ fn main() -> Result<()> {
 
     // Unified conversion function with type selection
     let serialized_graph = match args.input_type {
-        InputType::Synth => json_to_rdf::<SynthBatch>(&input_content, &args.format),
-        InputType::HCI => json_to_rdf::<CampaignWrapper>(&input_content, &args.format),
+        InputType::Synth => json_to_rdf::<SynthBatch>(&input_content, &args.format, args.materialize),
+        InputType::HCI => json_to_rdf::<CampaignWrapper>(&input_content, &args.format, args.materialize),
         InputType::Agilent => json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(
             &input_content,
             &args.format,
+            args.materialize,
         ),
     }
     .with_context(|| format!("Failed to convert JSON to RDF format '{:?}'", &args.format))?;

--- a/src/converter/tests/agilent_tests.rs
+++ b/src/converter/tests/agilent_tests.rs
@@ -6,6 +6,31 @@ use converter::convert::{json_to_rdf, RdfFormat};
 use sophia_isomorphism::isomorphic_graphs;
 
 #[test]
+fn test_materialize_blank_nodes() {
+    let output_format = RdfFormat::Turtle;
+    let json_data = r#"
+    {
+        "liquid chromatography aggregate document": {
+            "liquid chromatography document": [
+                {
+                    "analyst": "Swisscat (swisscat)",
+                    "measurement aggregate document": {
+                        "measurement document": []
+                    }
+                }
+            ]
+        }
+    }
+    "#;
+    let result = json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(
+        json_data,
+        &output_format,
+        true,
+    );
+    println!("{}", result.unwrap());
+}
+
+#[test]
 fn test_convert_liquid_chromatography() {
     let output_format = RdfFormat::Turtle;
     let json_data = r#"

--- a/src/converter/tests/agilent_tests.rs
+++ b/src/converter/tests/agilent_tests.rs
@@ -202,8 +202,11 @@ fn test_convert_liquid_chromatography() {
         }
     }
     "#;
-    let result =
-        json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(json_data, &output_format, false);
+    let result = json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(
+        json_data,
+        &output_format,
+        false,
+    );
     println!("{:?}", result);
     let expected_ttl = r#"
 
@@ -369,8 +372,11 @@ fn test_convert_device_system_document() {
         }
     }
     "#;
-    let result =
-        json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(json_data, &output_format, false);
+    let result = json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(
+        json_data,
+        &output_format,
+        false,
+    );
     let expected_ttl = r#"
     PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

--- a/src/converter/tests/agilent_tests.rs
+++ b/src/converter/tests/agilent_tests.rs
@@ -203,7 +203,7 @@ fn test_convert_liquid_chromatography() {
     }
     "#;
     let result =
-        json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(json_data, &output_format);
+        json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(json_data, &output_format, false);
     println!("{:?}", result);
     let expected_ttl = r#"
 
@@ -370,7 +370,7 @@ fn test_convert_device_system_document() {
     }
     "#;
     let result =
-        json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(json_data, &output_format);
+        json_to_rdf::<LiquidChromatographyAggregateDocumentWrapper>(json_data, &output_format, false);
     let expected_ttl = r#"
     PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

--- a/src/converter/tests/hci_tests.rs
+++ b/src/converter/tests/hci_tests.rs
@@ -105,7 +105,7 @@ fn test_convert_campaign() {
             }
         }
     "#;
-    let result = json_to_rdf::<CampaignWrapper>(json_data, &output_format);
+    let result = json_to_rdf::<CampaignWrapper>(json_data, &output_format, false);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

--- a/src/converter/tests/synth_tests.rs
+++ b/src/converter/tests/synth_tests.rs
@@ -22,7 +22,7 @@ fn test_convert_filtrate_action() {
             ]
         }
     "#;
-    let result = json_to_rdf::<SynthBatch>(json_data, &output_format);
+    let result = json_to_rdf::<SynthBatch>(json_data, &output_format, false);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -90,7 +90,7 @@ fn test_convert_pressure_action() {
             ]
         }
     "#;
-    let result = json_to_rdf::<SynthBatch>(json_data, &output_format);
+    let result = json_to_rdf::<SynthBatch>(json_data, &output_format, false);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -180,7 +180,7 @@ fn test_convert_set_temperature_action() {
                 ]
             }
         "#;
-    let result = json_to_rdf::<SynthBatch>(json_data, &output_format);
+    let result = json_to_rdf::<SynthBatch>(json_data, &output_format, false);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -339,7 +339,7 @@ fn test_convert_add_action() {
         ]
     }
     "#;
-    let result = json_to_rdf::<SynthBatch>(json_data, &output_format);
+    let result = json_to_rdf::<SynthBatch>(json_data, &output_format, false);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -485,7 +485,7 @@ fn test_convert_shake_action() {
             ]
         }
     "#;
-    let result = json_to_rdf::<SynthBatch>(json_data, &output_format);
+    let result = json_to_rdf::<SynthBatch>(json_data, &output_format, false);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -571,7 +571,7 @@ fn test_convert_set_vacuum_action() {
             ]
         }
     "#;
-    let result = json_to_rdf::<SynthBatch>(json_data, &output_format);
+    let result = json_to_rdf::<SynthBatch>(json_data, &output_format, false);
     let expected_ttl = r#"
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>


### PR DESCRIPTION
## Context
When debugging shacl validation, the non-deterministic URIs of blank nodes are a major pain points.
This PR allows the graph builder to "materialize" blank nodes by serializing them to a fixed URI.

## Changes summary

*  Adds a `materialize_blank_nodes` method on `GraphBuilder`.
* Adds a `--materialize` CLI flag to convert
* smoke test for node materialization

This supersedes #35.

## Example

Example taken from tests:
```turtle
PREFIX allores: <http://purl.allotrope.org/ontologies/result#>

[] a allores:AFR_0002524;
  cat:hasLiquidChromatography [ 
    a allores:AFR_0002525;
    allores:AFR_0001116 "Swisscat (swisscat)"
  ] .
```

becomes:
```turtle
PREFIX allores: <http://purl.allotrope.org/ontologies/result#>

<http://example.org/cat/resource/55e73785-38f9-4ac7-9e0c-653bb4c0bc5e> a allores:AFR_0002524;
  cat:hasLiquidChromatography <http://example.org/cat/resource/be7dda7a-a523-423e-a88c-e195c61b88d3>.

<http://example.org/cat/resource/be7dda7a-a523-423e-a88c-e195c61b88d3> a allores:AFR_0002525;
  allores:AFR_0001116 "Swisscat (swisscat)" .

```