### PR TITLE
fix: match schema.org/contentUrl (no trailing caps)

### DIFF
--- a/src/catplus-common/src/graph/graph_builder.rs
+++ b/src/catplus-common/src/graph/graph_builder.rs
@@ -45,16 +45,16 @@ impl GraphBuilder {
 
         // exit with warning if no triples are found.
         if triples.is_empty() {
-            println!("Warning: No triples found for contentURL insertion.");
+            println!("Warning: No triples found for contentUrl insertion.");
             return Ok(());
         } else if triples.len() > 1 {
-            return Err(anyhow::anyhow!("Multiple triples found for contentURL insertion"));
+            return Err(anyhow::anyhow!("Multiple triples found for contentUrl insertion"));
         }
 
         // return error if more than one triple is found
         if triples.len() > 1 {
             return Err(anyhow::anyhow!(
-                "Multiple triples found for contentURL insertion. There should only be one."
+                "Multiple triples found for contentUrl insertion. There should only be one."
             ));
         }
 
@@ -65,20 +65,20 @@ impl GraphBuilder {
             SimpleTerm::Iri(subject_iri) => {
                 self.graph.insert(
                     IriRef::new(subject_iri.as_str().to_owned()).unwrap(),
-                    schema::contentURL.as_simple(),
+                    schema::contentUrl.as_simple(),
                     content_url.as_simple(),
                 )?;
             }
             SimpleTerm::BlankNode(subject_bnode) => {
                 self.graph.insert(
                     subject_bnode.clone(),
-                    schema::contentURL.as_simple(),
+                    schema::contentUrl.as_simple(),
                     content_url.as_simple(),
                 )?;
             }
             _ => {
                 return Err(anyhow::anyhow!(
-                    "Subject must be either an IRI or a BlankNode to add contentURL"
+                    "Subject must be either an IRI or a BlankNode to add contentUrl"
                 ));
             }
         }

--- a/src/catplus-common/src/graph/namespaces/schema.rs
+++ b/src/catplus-common/src/graph/namespaces/schema.rs
@@ -3,7 +3,7 @@ use sophia::api::ns::Namespace;
 use sophia_api::namespace;
 namespace! {
     "https://schema.org/",
-    contentURL,
+    contentUrl,
     description,
     keywords,
     name

--- a/src/converter/tests/agilent_tests.rs
+++ b/src/converter/tests/agilent_tests.rs
@@ -144,7 +144,7 @@ fn test_convert_liquid_chromatography() {
                         allores:AFR_0001181 [ a cat:Measurement;
                             qudt:unit qudtext:MilliAbsorbanceUnit;
                             qudt:value "-183.143"^^xsd:double]]]]]];
-                        schema:contentURL "http://example.org/test/../../data/tests/agilent_liquid_chromatography_aggregate_document.json".
+                        schema:contentUrl "http://example.org/test/../../data/tests/agilent_liquid_chromatography_aggregate_document.json".
 
       "#;
     let expected_graph = parse_turtle_to_graph(&expected_ttl).unwrap();
@@ -196,7 +196,7 @@ fn test_convert_device_system_document() {
             allores:AFR_0002018 "Sampler";
             allores:AFR_0002568 "Autosampler";
             obo:IAO_0000017 "G7167A"]];
-        schema:contentURL "http://example.org/test/../../data/tests/agilent_device_system_document.json".
+        schema:contentUrl "http://example.org/test/../../data/tests/agilent_device_system_document.json".
 
     "#;
     let expected_graph = parse_turtle_to_graph(&expected_ttl).unwrap();

--- a/src/converter/tests/hci_tests.rs
+++ b/src/converter/tests/hci_tests.rs
@@ -109,7 +109,7 @@ fn test_convert_campaign() {
         allores:AFR_0002764 "Substitution reaction - SN2";
         schema:description "1-step N-methylation of theobromine to caffeine";
         schema:name "Caffeine Synthesis";
-        schema:contentURL "http://example.org/test/../../data/tests/hci_campaign.json".
+        schema:contentUrl "http://example.org/test/../../data/tests/hci_campaign.json".
     "#;
     let expected_graph = parse_turtle_to_graph(&expected_ttl).unwrap();
     let result_ttl = result.as_ref().unwrap().as_str();


### PR DESCRIPTION
ontology uses schema.org/contentUrl, but converter produces schema.org/contentURL. Let's stick to schema.org